### PR TITLE
Nil check `tech.unit` before attempting use as it is `nil` on trigger technologies.

### DIFF
--- a/prototypes/technology.lua
+++ b/prototypes/technology.lua
@@ -579,8 +579,13 @@ end
 
 local function add_science_pack(tech_name, science_pack)
   local tech = data.raw.technology[tech_name]
-  tech.unit.ingredients = tech.unit.ingredients or {}
-  table.insert(tech.unit.ingredients, science_pack)
+  -- If `tech.unit` doesn't exist then it is a trigger tech rather than a science tech, cannot modify it in this way
+  if tech.unit then
+    tech.unit.ingredients = tech.unit.ingredients or {}
+    table.insert(tech.unit.ingredients, science_pack)
+  else
+    log("Paracelsin: Unable to add science to tech `" .. tech_name .. "` due to it being a trigger technology, skipped.")
+  end
 end
 local function add_tech_effect(tech_name, effect)
   local tech = data.raw.technology[tech_name]


### PR DESCRIPTION
Nil check `tech.unit` before attempting use as it is `nil` on trigger technologies.

As per https://lua-api.factorio.com/latest/prototypes/TechnologyPrototype.html#unit `tech.unit` is optional (specifically it is nil when it is a trigger technology) and must be `nil` checked prior to use.

Also added a log message in the event this case is hit.  Unable to find any other `log` in this mod so uncertain what is the preferred format, so just followed a general format.

A more cohesive format might be to walk the dependency chain of the technology and add the science to the nearest pre-requisite, but that is both more work and may have unexpected consequences.  An alternative might be to at least have the technology for this science (or something else that makes sense) added to the pre-requisite list for the trigger technology as well.