### PR TITLE
[Fix] Fixed incompatibile zinc rivets and zinc solder recipes for mods that add multiple characters (Multiple Characters mod)

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -92,11 +92,12 @@ data.raw.item["accumulator-v2"].default_import_location = "paracelsin"
 data.raw.item["accumulator-v2"].weight = 100000
 
 local function add_player_crafting_categories(categories)
-    local entity = data.raw.character.character
+  for _, entity in pairs(data.raw.character) do  -- iterate all characters
     for _,category in pairs(categories) do
       table.insert(entity.crafting_categories, category)
-    end
+    end 
   end
+end
   
   add_player_crafting_categories({"hand-crafting"})
 


### PR DESCRIPTION
## Issue:
Mods that add multiple characters that load before this mod like [Multiple Characters](https://mods.factorio.com/mod/multiple-characters) are unable to use the custom hand crafting recipe due to only applying to the base character rather than `data.raw.character`

## Changes:
Modified the `add_player_crafting_categories` function to loop over all characters rather than assigning the category to the base character

## Testing:
Tested in a large modlist with no issues

## Notes: 
A bug report has also been added on the Factorio mods page for this mod (https://mods.factorio.com/mod/Paracelsin/discussion/69ab2631e8f4d9a712cbed21)