### PR TITLE
[Fix] same as #10 but now with more checking to prevent crashes when character prototypes don't have a crafting category

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -92,12 +92,15 @@ data.raw.item["accumulator-v2"].default_import_location = "paracelsin"
 data.raw.item["accumulator-v2"].weight = 100000
 
 local function add_player_crafting_categories(categories)
-    local entity = data.raw.character.character
-    for _,category in pairs(categories) do
+for _, entity in pairs(data.raw.character) do
+  if entity.crafting_categories then
+    for _, category in pairs(categories) do
       table.insert(entity.crafting_categories, category)
+      end
     end
   end
-  
+end
+
 add_player_crafting_categories({"hand-crafting"})
 
 require "prototypes.items"


### PR DESCRIPTION
Sorry about the crash caused by my last PR, I had no idea character prototypes could come with no `crafting_recipes` field, should be fixed now with checking if the field exists before modifying, I can't trigger it anymore with a custom character prototype without the `crafting_recipes` field after checking if it exists.

Sorry about the hassle once again, if you feel like this shouldn't be added due to the previous crash, no worries!